### PR TITLE
Test workaround

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,5 @@
 name: Run tests
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   runtests:

--- a/src/Demo.Api/MinimalApiTestConfiguration.cs
+++ b/src/Demo.Api/MinimalApiTestConfiguration.cs
@@ -1,0 +1,31 @@
+namespace Microsoft.Extensions.Configuration;
+
+public static class MinimalApiTestConfiguration
+{
+    // This async local is set in from tests and it flows to main
+    internal static readonly AsyncLocal<Action<IConfigurationBuilder>?> _current = new();
+
+    /// <summary>
+    /// Adds the current test configuration to the application in the "right" place
+    /// </summary>
+    /// <param name="configurationBuilder">The configuration builder</param>
+    /// <returns>The modified <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddTestConfiguration(this IConfigurationBuilder configurationBuilder)
+    {
+        if (_current.Value is { } configure)
+        {
+            configure(configurationBuilder);
+        }
+
+        return configurationBuilder;
+    }
+
+    /// <summary>
+    /// Unit tests can use this to flow state to the main program and change configuration
+    /// </summary>
+    /// <param name="action"></param>
+    public static void Configure(Action<IConfigurationBuilder> action)
+    {
+        _current.Value = action;
+    }
+}

--- a/src/Demo.Api/Program.cs
+++ b/src/Demo.Api/Program.cs
@@ -1,5 +1,7 @@
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddTestConfiguration();
+
 builder.Services.AddSingleton(new Options(builder.Configuration["AppSettings:Options"]));
 
 var app = builder.Build();

--- a/test/Demo.Test/TestServerFixture.cs
+++ b/test/Demo.Test/TestServerFixture.cs
@@ -10,20 +10,19 @@ public class TestServerFixture : WebApplicationFactory<Program>
 {
     internal Dictionary<string, string> OverrideConfiguration = new();
 
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    protected override IWebHostBuilder? CreateWebHostBuilder()
     {
-        base.ConfigureWebHost(builder);
+        MinimalApiTestConfiguration.Configure(builder =>
+        {
+            System.Console.WriteLine("configure test");
+            var testDir = Path.GetDirectoryName(GetType().Assembly.Location);
+            var configLocation = Path.Combine(testDir!, "testsettings.json");
 
-        builder
-            .ConfigureAppConfiguration((ctx, builder) =>
-            {
-                System.Console.WriteLine("configure test");
-                var testDir = Path.GetDirectoryName(GetType().Assembly.Location);
-                var configLocation = Path.Combine(testDir!, "testsettings.json");
+            builder.Sources.Clear();
+            builder.AddJsonFile(configLocation);
+            builder.AddInMemoryCollection(OverrideConfiguration);
+        });
 
-                builder.Sources.Clear();
-                builder.AddJsonFile(configLocation);
-                builder.AddInMemoryCollection(OverrideConfiguration);
-            });
+        return base.CreateWebHostBuilder();
     }
 }


### PR DESCRIPTION
Workaround suggested [here](https://github.com/dotnet/aspnetcore/issues/37680#issuecomment-1331559463) to load test configuration before it's used in startup.