### PR TITLE
UseSetting only

### DIFF
--- a/test/Demo.Test/TestServerFixture.cs
+++ b/test/Demo.Test/TestServerFixture.cs
@@ -12,18 +12,21 @@ public class TestServerFixture : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        foreach (var setting in OverrideConfiguration)
+        {
+            builder.UseSetting(setting.Key, setting.Value);
+        }
+
         base.ConfigureWebHost(builder);
 
         builder
             .ConfigureAppConfiguration((ctx, builder) =>
             {
-                System.Console.WriteLine("configure test");
                 var testDir = Path.GetDirectoryName(GetType().Assembly.Location);
                 var configLocation = Path.Combine(testDir!, "testsettings.json");
 
                 builder.Sources.Clear();
                 builder.AddJsonFile(configLocation);
-                builder.AddInMemoryCollection(OverrideConfiguration);
             });
     }
 }


### PR DESCRIPTION
Using [builder.UseSetting](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.webhostbuilder.usesetting?view=aspnetcore-7.0) means that [resolving settings during startup](https://github.com/tl-maisie-sadler/net6-config-error/blob/chore/usesetting/test/Demo.Test/UnitTest1.cs#L36) starts working but [resolving the settings inside a service](https://github.com/tl-maisie-sadler/net6-config-error/blob/chore/usesetting/test/Demo.Test/UnitTest1.cs#L50) breaks